### PR TITLE
fix building for libusb 

### DIFF
--- a/gaster.c
+++ b/gaster.c
@@ -18,12 +18,15 @@
 #	include <openssl/evp.h>
 #	include <stdbool.h>
 #	include <string.h>
+#   include <stddef.h>
+
 #else
 #	include <CommonCrypto/CommonCrypto.h>
 #	include <CoreFoundation/CoreFoundation.h>
 #	include <IOKit/IOCFPlugIn.h>
 #	include <IOKit/usb/IOUSBLib.h>
 #endif
+
 
 #define DFU_DNLOAD (1)
 #define AES_CMD_DEC (1U)

--- a/gaster.c
+++ b/gaster.c
@@ -18,7 +18,7 @@
 #	include <openssl/evp.h>
 #	include <stdbool.h>
 #	include <string.h>
-#   include <stddef.h>
+#	include <stddef.h>
 
 #else
 #	include <CommonCrypto/CommonCrypto.h>


### PR DESCRIPTION
a missing include for stddef.h was causing build errors on linux.